### PR TITLE
ci: add SBOM generation workflow

### DIFF
--- a/.github/workflows/create_sbom.yml
+++ b/.github/workflows/create_sbom.yml
@@ -1,0 +1,63 @@
+name: Generate SBOM
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  sbom-backend:
+    name: SBOM (Go backend)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: src/main/go.mod
+
+      - name: Generate SBOM
+        uses: CycloneDX/gh-gomod-generate-sbom@efc74245d6802c8cefd925620515442756c70d8f # v2.0.0
+        with:
+          version: v1
+          args: mod -licenses -json -output bom-backend.json ./src/main/
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sbom-backend-cyclonedx
+          path: bom-backend.json
+
+  sbom-frontend:
+    name: SBOM (Vue.js frontend)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        working-directory: src/frontend
+        run: npm ci
+
+      - name: Generate SBOM
+        uses: CycloneDX/gh-node-module-generatebom@27e13c2bf0fae78d66387b35ca9749d8cc853060 # v1.0.3
+        with:
+          path: src/frontend/
+          output: bom-frontend.json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sbom-frontend-cyclonedx
+          path: bom-frontend.json


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow (`create_sbom.yml`) that generates CycloneDX JSON SBOMs for both components:
  - **Go backend** (`src/main/`) via `CycloneDX/gh-gomod-generate-sbom`
  - **Vue.js frontend** (`src/frontend/`) via `CycloneDX/gh-node-module-generatebom`
- Runs on push and PR to `main`, uploads SBOMs as build artifacts

## Details
- SBOM format: CycloneDX JSON
- All action references are pinned to full commit SHAs for supply chain security
- Backend and frontend SBOM jobs run in parallel

## Test plan
- [ ] Verify both workflow jobs run successfully on the PR
- [ ] Check that `sbom-backend-cyclonedx` and `sbom-frontend-cyclonedx` artifacts are produced with valid CycloneDX JSON

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced automated Software Bill of Materials (SBOM) generation and publishing. Complete dependency manifests in CycloneDX v1 format, including license information, are now generated and published as build artifacts for backend and frontend components on every push and pull request to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->